### PR TITLE
several changes to the `DataFrame` and `Series` classes in the `pandas` library

### DIFF
--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -103,6 +103,7 @@ pub impl Show for DataFrame with output(self, logger) {
 /// # Parameters
 ///
 /// - `self` : An instance of the DataFrame
+/// - `num` : The number of rows to display (default is 5)
 ///
 /// # Returns
 ///
@@ -111,6 +112,7 @@ pub impl Show for DataFrame with output(self, logger) {
 /// # Example
 /// ```
 /// df.head()
+/// df.head(3)
 /// ```
 pub fn DataFrame::head(self : DataFrame, num? : Int) -> Unit {
   let mut row_str = "\t"

--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -112,13 +112,17 @@ pub impl Show for DataFrame with output(self, logger) {
 /// ```
 /// df.head()
 /// ```
-pub fn DataFrame::head(self : DataFrame) -> Unit {
+pub fn DataFrame::head(self : DataFrame, num? : Int) -> Unit {
   let mut row_str = "\t"
   for col in self.data {
     row_str = row_str + col.name() + "\t"
   }
   row_str += "\n"
-  for i = 0; i < @math.minimum(5, self.shape()[0]); i = i + 1 {
+  let n = match num {
+    Some(n) => n
+    None => 5
+  }
+  for i = 0; i < @math.minimum(n, self.shape()[0]); i = i + 1 {
     row_str += i.to_string() + "\t"
     for col in self.data {
       match col.data() {

--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -703,6 +703,26 @@ pub fn hstack(self : DataFrame, other : DataFrame) -> DataFrame! {
   DataFrame::new!(data)
 }
 
+///|
+/// Clears all data in the DataFrame, resetting it to an empty state.
+///
+/// Parameters:
+///
+/// * `self` : The DataFrame to be cleared.
+/// * `n` : Optional parameter that specifies a size hint for clearing (default
+/// is 0). Currently not used.
+///
+/// Example:
+///
+/// ```moonbit
+/// df.clear()
+/// ```
+pub fn DataFrame::clear(self : DataFrame, n~ : Int = 0) -> Unit {
+  self.data.clear()
+  self.shape = [0, 0]
+  self.index.clear()
+}
+
 ///| Tests
 test "new" {
   let df = DataFrame::new!([

--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -112,7 +112,7 @@ pub impl Show for DataFrame with output(self, logger) {
 /// # Example
 /// ```
 /// df.head()
-/// df.head(3)
+/// df.head(num=3)
 /// ```
 pub fn DataFrame::head(self : DataFrame, num? : Int) -> Unit {
   let mut row_str = "\t"

--- a/src/lib/pandas/series.mbt
+++ b/src/lib/pandas/series.mbt
@@ -4,7 +4,7 @@ pub(all) enum DType {
   Float(Float)
   Bool(Bool)
   Str(String)
-} derive(Show, Eq, Compare)
+} derive(Show, Eq, Compare, Hash)
 
 ///|
 pub(all) enum SeriesData {

--- a/src/lib/pandas/series.mbt
+++ b/src/lib/pandas/series.mbt
@@ -294,6 +294,17 @@ pub fn op_div(self : Series, other : Series) -> Series {
   Series::new(self.name(), self.data() / other.data())
 }
 
+pub fn merge(self : Series, other : Series) -> Series!InvalidType {
+  let data = match (self.data, other.data) {
+    (SeriesData::Int(a), SeriesData::Int(b)) => SeriesData::Int(a + b)
+    (SeriesData::Float(a), SeriesData::Float(b)) => SeriesData::Float(a + b)
+    (SeriesData::Bool(a), SeriesData::Bool(b)) => SeriesData::Bool(a + b)
+    (SeriesData::Str(a), SeriesData::Str(b)) => SeriesData::Str(a + b)
+    _ => raise InvalidType("unsupported types")
+  }
+  Series::new(self.name, data)
+}
+
 ///| Tests
 test "series" {
   let series = Series::new("test", SeriesData::Int([1, 2, 3, 4, 5]))


### PR DESCRIPTION
This pull request includes several changes to the `DataFrame` and `Series` classes in the `pandas` library. The key updates introduce new functionality and enhance existing methods.

Enhancements to `DataFrame`:

* Added an optional `num` parameter to the `head` method, allowing users to specify the number of rows to display. [[1]](diffhunk://#diff-c9da96133f981ecd293f16398226f6f2657109fe1456ed6bd7f5babdd2292efeR106) [[2]](diffhunk://#diff-c9da96133f981ecd293f16398226f6f2657109fe1456ed6bd7f5babdd2292efeR115-R127)
* Introduced a new `clear` method to reset the `DataFrame` to an empty state.

Enhancements to `Series`:

* Added a new `merge` method to combine two `Series` objects, supporting different data types.
* Updated the `DType` enum to derive the `Hash` trait, enabling hashing of `DType` values.