### PR TITLE
introduces several new functionalities and improvements to the `DataFrame` and `Series` classes in the `pandas` library.

### DIFF
--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -801,6 +801,71 @@ pub fn DataFrame::item(
   self.data[col][row]
 }
 
+///|
+/// Creates a new DataFrame containing only the first N rows of the original
+/// DataFrame. If N is larger than the number of rows in the DataFrame, returns a
+/// DataFrame with all rows from the original DataFrame.
+///
+/// Parameters:
+///
+/// * `self` : The DataFrame to limit.
+/// * `n` : The maximum number of rows to include in the new DataFrame.
+///
+/// Returns a new DataFrame containing at most N rows from the original
+/// DataFrame.
+///
+/// Throws an error of type `Error` if creating the new DataFrame fails.
+///
+/// Example:
+///
+/// ```moonbit
+/// let df = DataFrame::new!([
+///   Series::new("A", SeriesData::Int([1, 2, 3, 4, 5])),
+///   Series::new("B", SeriesData::Float([1.1, 2.2, 3.3, 4.4, 5.5])),
+/// ])
+/// let limited = df.limit!(3)
+/// ```
+pub fn limit(self : DataFrame, n : Int) -> DataFrame!Error {
+  let data : Array[Series] = []
+  let n = @math.minimum(n, self.shape()[0])
+  let mut count = 0
+  for series in self.data {
+    let new_data = match series.data {
+      SeriesData::Int(data) => {
+        data.resize(n, 0)
+        SeriesData::Int(data)
+      }
+      SeriesData::Float(data) => {
+        data.resize(n, 0.0)
+        SeriesData::Float(data)
+      }
+      SeriesData::Bool(data) => {
+        data.resize(n, false)
+        SeriesData::Bool(data)
+      }
+      SeriesData::Str(data) => {
+        data.resize(n, "")
+        SeriesData::Str(data)
+      }
+      SeriesData::List(data) => {
+        data.resize(
+          n,
+          match data {
+            [SeriesData::Int(_)] => SeriesData::Int([])
+            [SeriesData::Float(_)] => SeriesData::Float([])
+            [SeriesData::Bool(_)] => SeriesData::Bool([])
+            [SeriesData::Str(_)] => SeriesData::Str([])
+            _ => SeriesData::List([])
+          },
+        )
+        SeriesData::List(data)
+      }
+    }
+    data.push(Series::new(series.name, new_data))
+  }
+  DataFrame::new!(data)
+}
+
 ///| Tests
 test "new" {
   let df = DataFrame::new!([

--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -754,6 +754,34 @@ pub fn DataFrame::clone(self : DataFrame) -> DataFrame {
 }
 
 ///|
+/// Retrieves a single item from the DataFrame at the specified row and column.
+///
+/// Parameters:
+///
+/// * `self` : The DataFrame to retrieve the item from.
+/// * `row` : The index of the row (zero-based).
+/// * `column` : The column identifier, can be either:
+///  * `DType::Int`: A zero-based index of the column
+///  * `DType::Str`: The name of the column
+///
+/// Returns a `DType` value representing the item at the specified position.
+///
+/// Throws:
+///
+/// * `ColumnNotFoundError` : If the specified column name does not exist in the
+/// DataFrame
+/// * `IndexOutOfBounds` : If the row index is out of range
+///
+/// Example:
+///
+/// ```moonbit
+/// let df = DataFrame::new!([
+///   Series::new("A", SeriesData::Int([1, 2, 3])),
+///   Series::new("B", SeriesData::Float([1.5, 2.0, 3.5])),
+/// ])
+/// df.item!(1, DType::Str("A"))
+/// df.item!(0, DType::Int(1))
+/// ```
 pub fn DataFrame::item(
   self : DataFrame,
   row : Int,

--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -723,6 +723,35 @@ pub fn DataFrame::clear(self : DataFrame, n~ : Int = 0) -> Unit {
   self.index.clear()
 }
 
+///|
+/// Creates a deep copy of the DataFrame.
+///
+/// Parameters:
+///
+/// * `self` : The DataFrame to be cloned.
+///
+/// Returns a new DataFrame with the same data, shape, and index as the original
+/// DataFrame. All internal data structures are deeply copied.
+///
+/// Example:
+///
+/// ```moonbit
+/// let df = DataFrame::new!([
+///   Series::new("A", SeriesData::Int([1, 2, 3])),
+///   Series::new("B", SeriesData::Float([1.0, 2.0, 3.0])),
+/// ])
+/// let cloned = df.clone()
+/// ```
+pub fn DataFrame::clone(self : DataFrame) -> DataFrame {
+  let data = self.data.map(fn(series : Series) { series.copy() })
+  let index = self.index.iter().collect()
+  let map : Map[String, Int] = {}
+  for idx in index {
+    map[idx.0] = idx.1
+  }
+  DataFrame::{ data, shape: self.shape.copy(), index: map }
+}
+
 ///| Tests
 test "new" {
   let df = DataFrame::new!([

--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -732,6 +732,7 @@ pub fn DataFrame::clear(self : DataFrame, n~ : Int = 0) -> Unit {
 ///
 /// Returns a new DataFrame with the same data, shape, and index as the original
 /// DataFrame. All internal data structures are deeply copied.
+/// THIS METHOD Under Consideration...
 ///
 /// Example:
 ///
@@ -750,6 +751,26 @@ pub fn DataFrame::clone(self : DataFrame) -> DataFrame {
     map[idx.0] = idx.1
   }
   DataFrame::{ data, shape: self.shape.copy(), index: map }
+}
+
+///|
+pub fn DataFrame::item(
+  self : DataFrame,
+  row : Int,
+  column : DType
+) -> DType!Error {
+  let col = match column {
+    DType::Int(value) => value
+    DType::Str(value) =>
+      match self.index.get(value) {
+        Some(idx) => idx
+        None => raise ColumnNotFoundError("Column '\{value}' not found")
+      }
+  }
+  if row < 0 || row >= self.shape()[0] {
+    raise IndexOutOfBounds("Row index out of bounds")
+  }
+  self.data[col][row]
 }
 
 ///| Tests

--- a/src/lib/pandas/moon.pkg.json
+++ b/src/lib/pandas/moon.pkg.json
@@ -1,1 +1,5 @@
-{}
+{
+    "is-main": false,
+    "dependencies": {},
+    "import": []
+}

--- a/src/lib/pandas/series.mbt
+++ b/src/lib/pandas/series.mbt
@@ -294,6 +294,7 @@ pub fn op_div(self : Series, other : Series) -> Series {
   Series::new(self.name(), self.data() / other.data())
 }
 
+///|
 pub fn merge(self : Series, other : Series) -> Series!InvalidType {
   let data = match (self.data, other.data) {
     (SeriesData::Int(a), SeriesData::Int(b)) => SeriesData::Int(a + b)
@@ -303,6 +304,21 @@ pub fn merge(self : Series, other : Series) -> Series!InvalidType {
     _ => raise InvalidType("unsupported types")
   }
   Series::new(self.name, data)
+}
+
+///|
+fn copy(self : SeriesData) -> SeriesData {
+  match self {
+    SeriesData::Int(data) => SeriesData::Int(data.copy())
+    SeriesData::Float(data) => SeriesData::Float(data.copy())
+    SeriesData::Bool(data) => SeriesData::Bool(data.copy())
+    SeriesData::Str(data) => SeriesData::Str(data.copy())
+  }
+}
+
+///|
+pub fn copy(self : Series) -> Series {
+  Series::new(self.name(), self.data().copy())
 }
 
 ///| Tests

--- a/src/lib/pandas/series.mbt
+++ b/src/lib/pandas/series.mbt
@@ -4,7 +4,8 @@ pub(all) enum DType {
   Float(Float)
   Bool(Bool)
   Str(String)
-} derive(Show, Eq, Compare, Hash)
+  List(Array[DType])
+} derive(Show, Eq, Compare)
 
 ///|
 pub(all) enum SeriesData {
@@ -12,6 +13,7 @@ pub(all) enum SeriesData {
   Float(Array[Float])
   Bool(Array[Bool])
   Str(Array[String])
+  List(Array[SeriesData])
 } derive(Show, Eq)
 
 ///|
@@ -230,6 +232,22 @@ pub fn op_sub(self : SeriesData, other : SeriesData) -> SeriesData {
       SeriesData::Float(res)
     }
     _ => abort("unsupported types")
+  }
+}
+
+pub fn op_get(self : Series, other : Int) -> DType {
+  match self.data {
+    SeriesData::Int(data) => DType::Int(data[other])
+    SeriesData::Float(data) => DType::Float(data[other])
+    SeriesData::Bool(data) => DType::Bool(data[other])
+    SeriesData::Str(data) => DType::Str(data[other])
+    SeriesData::List(data) => match data {
+      [SeriesData::Int(arr)] => DType::Int(arr[other])
+      [SeriesData::Float(arr)] => DType::Float(arr[other])
+      [SeriesData::Bool(arr)] => DType::Bool(arr[other])
+      [SeriesData::Str(arr)] => DType::Str(arr[other])
+      _ => abort("unsupported types")
+    }
   }
 }
 

--- a/src/lib/pandas/series.mbt
+++ b/src/lib/pandas/series.mbt
@@ -235,19 +235,21 @@ pub fn op_sub(self : SeriesData, other : SeriesData) -> SeriesData {
   }
 }
 
+///|
 pub fn op_get(self : Series, other : Int) -> DType {
   match self.data {
     SeriesData::Int(data) => DType::Int(data[other])
     SeriesData::Float(data) => DType::Float(data[other])
     SeriesData::Bool(data) => DType::Bool(data[other])
     SeriesData::Str(data) => DType::Str(data[other])
-    SeriesData::List(data) => match data {
-      [SeriesData::Int(arr)] => DType::Int(arr[other])
-      [SeriesData::Float(arr)] => DType::Float(arr[other])
-      [SeriesData::Bool(arr)] => DType::Bool(arr[other])
-      [SeriesData::Str(arr)] => DType::Str(arr[other])
-      _ => abort("unsupported types")
-    }
+    SeriesData::List(data) =>
+      match data {
+        [SeriesData::Int(arr)] => DType::Int(arr[other])
+        [SeriesData::Float(arr)] => DType::Float(arr[other])
+        [SeriesData::Bool(arr)] => DType::Bool(arr[other])
+        [SeriesData::Str(arr)] => DType::Str(arr[other])
+        _ => abort("unsupported types")
+      }
   }
 }
 


### PR DESCRIPTION
This pull request introduces several new functionalities and improvements to the `DataFrame` and `Series` classes in the `pandas` library. The key changes include the addition of methods for deep copying, item retrieval, and limiting rows in a DataFrame, as well as enhancements to the `Series` class to support new data types and operations.

New functionalities in `DataFrame`:

* Added `DataFrame::clone` method to create a deep copy of the DataFrame, including all internal data structures.
* Added `DataFrame::item` method to retrieve a single item from the DataFrame at a specified row and column.
* Added `DataFrame::limit` method to create a new DataFrame containing only the first N rows of the original DataFrame.

Enhancements to `Series`:

* Introduced `DType::List` and `SeriesData::List` to support list data types in Series.
* Added `Series::op_get` method to retrieve an item from a Series by index.
* Added `Series::copy` method to create a deep copy of a Series.

Other changes:

* Updated `moon.pkg.json` to include metadata and dependencies.