### PR TITLE
Update data_frame.mbt

### DIFF
--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -719,6 +719,144 @@ pub fn DataFrame::clear(self : DataFrame, n~ : Int = 0) -> Unit {
   self.index.clear()
 }
 
+<<<<<<< Updated upstream
+=======
+///|
+/// Creates a deep copy of the DataFrame.
+///
+/// Parameters:
+///
+/// * `self` : The DataFrame to be cloned.
+///
+/// Returns a new DataFrame with the same data, shape, and index as the original
+/// DataFrame. All internal data structures are deeply copied.
+/// THIS METHOD Under Consideration...
+///
+/// Example:
+///
+/// ```moonbit
+/// let df = DataFrame::new!([
+///   Series::new("A", SeriesData::Int([1, 2, 3])),
+///   Series::new("B", SeriesData::Float([1.0, 2.0, 3.0])),
+/// ])
+/// let cloned = df.clone()
+/// ```
+pub fn DataFrame::clone(self : DataFrame) -> DataFrame {
+  let data = self.data.map(fn(series : Series) { series.copy() })
+  let index = self.index.iter().collect()
+  let map : Map[String, Int] = {}
+  for idx in index {
+    map[idx.0] = idx.1
+  }
+  DataFrame::{ data, shape: self.shape.copy(), index: map }
+}
+
+///|
+/// Retrieves a single item from the DataFrame at the specified row and column.
+///
+/// Parameters:
+///
+/// * `self` : The DataFrame to retrieve the item from.
+/// * `row` : The index of the row (zero-based).
+/// * `column` : The column identifier, can be either:
+///  * `DType::Int`: A zero-based index of the column
+///  * `DType::Str`: The name of the column
+///
+/// Returns a `DType` value representing the item at the specified position.
+///
+/// Throws:
+///
+/// * `ColumnNotFoundError` : If the specified column name does not exist in the
+/// DataFrame
+/// * `IndexOutOfBounds` : If the row index is out of range
+///
+/// Example:
+///
+/// ```moonbit
+/// let df = DataFrame::new!([
+///   Series::new("A", SeriesData::Int([1, 2, 3])),
+///   Series::new("B", SeriesData::Float([1.5, 2.0, 3.5])),
+/// ])
+/// df.item!(1, DType::Str("A"))
+/// df.item!(0, DType::Int(1))
+/// ```
+pub fn DataFrame::item(
+  self : DataFrame,
+  row : Int,
+  column : DType
+) -> DType!Error {
+  let col = match column {
+    DType::Int(value) => value
+    DType::Str(value) =>
+      match self.index.get(value) {
+        Some(idx) => idx
+        None => raise ColumnNotFoundError("Column '\{value}' not found")
+      }
+  }
+  if row < 0 || row >= self.shape()[0] {
+    raise IndexOutOfBounds("Row index out of bounds")
+  }
+  self.data[col][row]
+}
+
+///|
+/// Creates a new DataFrame containing only the first N rows of the original
+/// DataFrame. If N is larger than the number of rows in the DataFrame, returns a
+/// DataFrame with all rows from the original DataFrame.
+///
+/// Parameters:
+///
+/// * `self` : The DataFrame to limit.
+/// * `n` : The maximum number of rows to include in the new DataFrame.
+///
+/// Returns a new DataFrame containing at most N rows from the original
+/// DataFrame.
+///
+/// Throws an error of type `Error` if creating the new DataFrame fails.
+///
+/// Example:
+///
+/// ```moonbit
+/// let df = DataFrame::new!([
+///   Series::new("A", SeriesData::Int([1, 2, 3, 4, 5])),
+///   Series::new("B", SeriesData::Float([1.1, 2.2, 3.3, 4.4, 5.5])),
+/// ])
+/// let limited = df.limit!(3)
+/// ```
+pub fn limit(self : DataFrame, n : Int) -> DataFrame!Error {
+  let data : Array[Series] = []
+  let n = @math.minimum(n, self.shape()[0])
+  for series in self.data {
+    let new_data = match series.data {
+      SeriesData::Int(data) => SeriesData::Int(data.split_at(n).0)
+      SeriesData::Float(data) => SeriesData::Float(data.split_at(n).0)
+      SeriesData::Bool(data) => SeriesData::Bool(data.split_at(n).0)
+      SeriesData::Str(data) => SeriesData::Str(data.split_at(n).0)
+      SeriesData::List(data) => SeriesData::List(data.split_at(n).0)
+    }
+    data.push(Series::new(series.name, new_data))
+  }
+  DataFrame::new!(data)
+}
+
+///|
+pub fn tail(self : DataFrame, n : Int) -> DataFrame!Error {
+  let data : Array[Series] = []
+  let n = @math.minimum(n, self.shape()[0])
+  for series in self.data {
+    let new_data = match series.data {
+      SeriesData::Int(data) => SeriesData::Int(data.split_at(data.length() - n).1)
+      SeriesData::Float(data) => SeriesData::Float(data.split_at(data.length() - n).1)
+      SeriesData::Bool(data) => SeriesData::Bool(data.split_at(data.length() - n).1)
+      SeriesData::Str(data) => SeriesData::Str(data.split_at(data.length() - n).1)
+      SeriesData::List(data) => SeriesData::List(data.split_at(data.length() - n).1)
+    }
+    data.push(Series::new(series.name, new_data))
+  }
+  DataFrame::new!(data)
+}
+
+>>>>>>> Stashed changes
 ///| Tests
 test "new" {
   let df = DataFrame::new!([


### PR DESCRIPTION
This pull request introduces several new methods to the `DataFrame` class in the `src/lib/pandas/data_frame.mbt` file, enhancing its functionality. The changes include methods for cloning a DataFrame, retrieving a specific item, limiting the number of rows, and getting the last N rows of the DataFrame.

Enhancements to the `DataFrame` class:

* Added `DataFrame::clone` method to create a deep copy of the DataFrame. This method ensures all internal data structures are deeply copied.
* Added `DataFrame::item` method to retrieve a single item from the DataFrame at a specified row and column. This method includes error handling for column not found and index out of bounds.
* Added `DataFrame::limit` method to create a new DataFrame containing only the first N rows of the original DataFrame. This method handles cases where N is larger than the number of rows in the DataFrame.
* Added `DataFrame::tail` method to create a new DataFrame containing the last N rows of the original DataFrame. This method ensures the correct subset of rows is selected.
[Copilot is generating a summary...]