### PR TITLE
add bounds check for op_get method in Series

### DIFF
--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -713,7 +713,7 @@ pub fn hstack(self : DataFrame, other : DataFrame) -> DataFrame! {
 /// ```moonbit
 /// df.clear()
 /// ```
-pub fn DataFrame::clear(self : DataFrame, n~ : Int = 0) -> Unit {
+pub fn DataFrame::clear(self : DataFrame) -> Unit {
   self.data.clear()
   self.shape = [0, 0]
   self.index.clear()
@@ -799,7 +799,7 @@ pub fn DataFrame::item(
   if row < 0 || row >= self.shape()[0] {
     raise IndexOutOfBounds("Row index out of bounds")
   }
-  self.data[col][row]
+  self.data[col].op_get!(row)
 }
 
 ///|

--- a/src/lib/pandas/data_frame.mbt
+++ b/src/lib/pandas/data_frame.mbt
@@ -799,7 +799,7 @@ pub fn DataFrame::item(
   if row < 0 || row >= self.shape()[0] {
     raise IndexOutOfBounds("Row index out of bounds")
   }
-  self.data[col].op_get!(row)
+  self.data[col][row]
 }
 
 ///|

--- a/src/lib/pandas/series.mbt
+++ b/src/lib/pandas/series.mbt
@@ -234,7 +234,18 @@ pub fn op_sub(self : SeriesData, other : SeriesData) -> SeriesData {
 }
 
 ///|
-pub fn op_get(self : Series, other : Int) -> DType {
+
+pub fn check_bounds(self: Series, index: Int) -> Unit!IndexOutOfBounds {
+  if index < 0 || index >= self.data.length() {
+    raise IndexOutOfBounds(
+      "Index \{index} is out of bounds"
+    )
+  }
+}
+
+pub fn op_get(self: Series, other: Int) -> DType!IndexOutOfBounds {
+  Series::check_bounds!(self, other)
+
   match self.data {
     SeriesData::Int(data) => DType::Int(data[other])
     SeriesData::Float(data) => DType::Float(data[other])
@@ -386,4 +397,54 @@ test "series_div" {
   inspect!(c, content="Int([2, 2, 3])")
   let c = a / b
   inspect!(c, content="{name: \"a\", data: Int([2, 2, 3])}")
+}
+
+test "op_get" {
+  // Int
+  let series_int = Series::new("IntSeries", SeriesData::Int([10, 20, 30, 40, 50]))
+  assert_eq!(series_int.op_get!(0), DType::Int(10))
+  assert_eq!(series_int.op_get!(4), DType::Int(50))
+
+  // Float
+  let series_float = Series::new("FloatSeries", SeriesData::Float([1.1, 2.2, 3.3]))
+  assert_eq!(series_float.op_get!(1), DType::Float(2.2))
+  assert_eq!(series_float.op_get!(2), DType::Float(3.3))
+
+  // Bool
+  let series_bool = Series::new("BoolSeries", SeriesData::Bool([true, false, true]))
+  assert_eq!(series_bool.op_get!(0), DType::Bool(true))
+  assert_eq!(series_bool.op_get!(1), DType::Bool(false))
+
+  // Str 
+  let series_str = Series::new("StrSeries", SeriesData::Str(["hello", "world"]))
+  assert_eq!(series_str.op_get!(0), DType::Str("hello"))
+  assert_eq!(series_str.op_get!(1), DType::Str("world"))
+
+  // over bounds
+  match series_int.op_get?(5) {
+    Err(IndexOutOfBounds(msg)) => {
+      println("Caught error: \{msg}")
+      assert_eq!(msg, "Index 5 is out of bounds")
+    }
+    _ => abort("Expected IndexOutOfBounds error for out-of-bounds index")
+  }
+
+  // negative index
+  match series_int.op_get?(-1) {
+    Err(IndexOutOfBounds(msg)) => {
+      println("Caught error: \{msg}")
+      assert_eq!(msg, "Index -1 is out of bounds")
+    }
+    _ => abort("Expected IndexOutOfBounds error for negative index")
+  }
+
+  // empty series
+  let empty_series = Series::new("EmptySeries", SeriesData::Int([]))
+  match empty_series.op_get?(0) {
+    Err(IndexOutOfBounds(msg)) => {
+      println("Caught error: \{msg}")
+      assert_eq!(msg, "Index 0 is out of bounds")
+    }
+    _ => abort("Expected IndexOutOfBounds error for empty Series")
+  }
 }


### PR DESCRIPTION
Already git pull latest original main, the code op_get has been simplify by adding another check_bounds method. Modifying the code in data_frame.mbt at 716 lines and 802 lines, thereby fixing the warning.